### PR TITLE
feat(movies): adds name column to movie table

### DIFF
--- a/db/migrations/20190214135959_add_name_to_movies.js
+++ b/db/migrations/20190214135959_add_name_to_movies.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.text('name');
+  })
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+};
+
+exports.down = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  })
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+};


### PR DESCRIPTION
**What:** Adds `name` column to `movies` table

**Why:** Preparation for migration of data from `title` to `name`

**Details:**

We have decided to rename the db field from `title` to `name`. This migration adds the `name` field, and also removes `NOT NULL` constraint on `title` column in preparation for deletion. Next PR will migrate data from `title` to `name` and update the code to point to the new column. Then one final PR will drop the `name` column.