### PR TITLE
feat(movies): drops title column from db

### DIFF
--- a/db/migrations/20190214142713_drop_title_from_movies.js
+++ b/db/migrations/20190214142713_drop_title_from_movies.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+};
+
+exports.down = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+};

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,7 +3,10 @@
 const Movie = require('../../../models/movie');
 
 exports.create = async (payload) => {
-  const movie = await new Movie().save(payload);
+  const newPayload = Object.assign({}, payload);
+  newPayload.name = newPayload.title;
+  Reflect.deleteProperty(newPayload, 'title');
+  const movie = await new Movie().save(newPayload);
 
   return new Movie({ id: movie.id }).fetch();
 };

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -11,7 +11,7 @@ describe('movie controller', () => {
 
       const movie = await Controller.create(payload);
 
-      expect(movie.get('title')).to.eql(payload.title);
+      expect(movie.get('name')).to.eql(payload.title);
     });
 
   });


### PR DESCRIPTION
**What:** Drops `title` db column 

**Why:** Column is no longer in use, has been renamed to `name`.

**Details:**

Third step of migration from `title` to `name`.